### PR TITLE
fix: update voice twiml to remove pointers on noun and verb attributes

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -12,20 +12,20 @@ on:
       - makefile
       - main.go
 
-env:
-  GO_VERSION: "1.14"
-  GO111MODULE: on
-
 jobs:
   pipeline:
-    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        go-version: [1.14.x, 1.15.x, 1.16.x]
+        os: [ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Go with v${{ env.GO_VERSION }}
+      - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Install tools
         run: make tools
@@ -38,6 +38,12 @@ jobs:
 
       - name: Test
         run: make test
+
+  Report:
+    runs-on: ubuntu-18.04
+    needs: pipeline
+    steps:
+      - uses: actions/checkout@v1
 
       - name: Refresh Go Report Card
         if: github.ref == 'refs/heads/main'

--- a/twiml/fax/fax_response.go
+++ b/twiml/fax/fax_response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 
 	"github.com/RJPearson94/twilio-sdk-go/twiml/fax/verbs"
+	"github.com/RJPearson94/twilio-sdk-go/utils"
 )
 
 // FaxResponse provides the structure and functions for generation TwiML that can be used
@@ -41,6 +42,5 @@ func (m *FaxResponse) ToString() (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-	twiML := xml.Header + string(output)
-	return &twiML, nil
+	return utils.String(xml.Header + string(output)), nil
 }

--- a/twiml/fax/verbs/receive.go
+++ b/twiml/fax/verbs/receive.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type ReceiveAttributes struct {
 	Action     *string `xml:"action,attr,omitempty"`

--- a/twiml/fax/verbs/reject.go
+++ b/twiml/fax/verbs/reject.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Reject struct {
 	XMLName xml.Name `xml:"Reject"`

--- a/twiml/messaging/messaging_response.go
+++ b/twiml/messaging/messaging_response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 
 	"github.com/RJPearson94/twilio-sdk-go/twiml/messaging/verbs"
+	"github.com/RJPearson94/twilio-sdk-go/utils"
 )
 
 // MessagingResponse provides the structure and functions for generation TwiML that can be used
@@ -21,13 +22,7 @@ func New() *MessagingResponse {
 }
 
 func (m *MessagingResponse) Message(body *string) *verbs.Message {
-	message := &verbs.Message{
-		Text:     body,
-		Children: make([]interface{}, 0),
-	}
-
-	m.Children = append(m.Children, message)
-	return message
+	return m.MessageWithAttributes(verbs.MessageAttributes{}, body)
 }
 
 func (m *MessagingResponse) MessageWithAttributes(attributes verbs.MessageAttributes, body *string) *verbs.Message {
@@ -42,9 +37,7 @@ func (m *MessagingResponse) MessageWithAttributes(attributes verbs.MessageAttrib
 }
 
 func (m *MessagingResponse) Redirect(url string) {
-	m.Children = append(m.Children, &verbs.Redirect{
-		Text: url,
-	})
+	m.RedirectWithAttributes(verbs.RedirectAttributes{}, url)
 }
 
 func (m *MessagingResponse) RedirectWithAttributes(attributes verbs.RedirectAttributes, url string) {
@@ -65,6 +58,5 @@ func (m *MessagingResponse) ToString() (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-	twiML := xml.Header + string(output)
-	return &twiML, nil
+	return utils.String(xml.Header + string(output)), nil
 }

--- a/twiml/messaging/verbs/message.go
+++ b/twiml/messaging/verbs/message.go
@@ -15,10 +15,9 @@ type MessageAttributes struct {
 
 type Message struct {
 	XMLName xml.Name `xml:"Message"`
+	Text    *string  `xml:",chardata"`
 
 	MessageAttributes
-
-	Text     *string `xml:",chardata"`
 	Children []interface{}
 }
 

--- a/twiml/messaging/verbs/nouns/body.go
+++ b/twiml/messaging/verbs/nouns/body.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Body struct {
 	XMLName xml.Name `xml:"Body"`

--- a/twiml/messaging/verbs/nouns/media.go
+++ b/twiml/messaging/verbs/nouns/media.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Media struct {
 	XMLName xml.Name `xml:"Media"`

--- a/twiml/messaging/verbs/redirect.go
+++ b/twiml/messaging/verbs/redirect.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type RedirectAttributes struct {
 	Method *string `xml:"method,attr,omitempty"`
@@ -8,8 +10,7 @@ type RedirectAttributes struct {
 
 type Redirect struct {
 	XMLName xml.Name `xml:"Redirect"`
+	Text    string   `xml:",chardata"`
 
 	RedirectAttributes
-
-	Text string `xml:",chardata"`
 }

--- a/twiml/voice/verbs/connect.go
+++ b/twiml/voice/verbs/connect.go
@@ -14,25 +14,24 @@ type ConnectAttributes struct {
 type Connect struct {
 	XMLName xml.Name `xml:"Connect"`
 
-	*ConnectAttributes
-
+	ConnectAttributes
 	Children []interface{}
 }
 
 func (c *Connect) Autopilot(name string) {
-	c.Children = append(c.Children, nouns.Autopilot{
+	c.Children = append(c.Children, &nouns.Autopilot{
 		Text: name,
 	})
 }
 
 func (c *Connect) Room(name string) {
-	c.Children = append(c.Children, nouns.Room{
+	c.Children = append(c.Children, &nouns.Room{
 		Text: name,
 	})
 }
 
 func (c *Connect) RoomWithAttributes(attributes nouns.RoomAttributes, name string) {
-	c.Children = append(c.Children, nouns.Room{
+	c.Children = append(c.Children, &nouns.Room{
 		Text:           name,
 		RoomAttributes: attributes,
 	})
@@ -48,7 +47,7 @@ func (c *Connect) Stream() *nouns.Stream {
 
 func (c *Connect) StreamWithAttributes(attributes nouns.StreamAttributes) *nouns.Stream {
 	stream := &nouns.Stream{
-		StreamAttributes: &attributes,
+		StreamAttributes: attributes,
 		Children:         make([]interface{}, 0),
 	}
 	c.Children = append(c.Children, stream)

--- a/twiml/voice/verbs/dial.go
+++ b/twiml/voice/verbs/dial.go
@@ -36,12 +36,7 @@ type Dial struct {
 }
 
 func (d *Dial) Client(identity *string) *nouns.Client {
-	client := &nouns.Client{
-		Text:     identity,
-		Children: make([]interface{}, 0),
-	}
-	d.Children = append(d.Children, client)
-	return client
+	return d.ClientWithAttributes(nouns.ClientAttributes{}, identity)
 }
 
 func (d *Dial) ClientWithAttributes(attributes nouns.ClientAttributes, identity *string) *nouns.Client {
@@ -55,9 +50,7 @@ func (d *Dial) ClientWithAttributes(attributes nouns.ClientAttributes, identity 
 }
 
 func (d *Dial) Conference(name string) {
-	d.Children = append(d.Children, &nouns.Conference{
-		Text: name,
-	})
+	d.ConferenceWithAttributes(nouns.ConferenceAttributes{}, name)
 }
 
 func (d *Dial) ConferenceWithAttributes(attributes nouns.ConferenceAttributes, name string) {
@@ -68,9 +61,7 @@ func (d *Dial) ConferenceWithAttributes(attributes nouns.ConferenceAttributes, n
 }
 
 func (d *Dial) Number(phoneNumber string) {
-	d.Children = append(d.Children, &nouns.Number{
-		Text: phoneNumber,
-	})
+	d.NumberWithAttributes(nouns.NumberAttributes{}, phoneNumber)
 }
 
 func (d *Dial) NumberWithAttributes(attributes nouns.NumberAttributes, phoneNumber string) {
@@ -81,14 +72,12 @@ func (d *Dial) NumberWithAttributes(attributes nouns.NumberAttributes, phoneNumb
 }
 
 func (d *Dial) Queue(name string) {
-	d.Children = append(d.Children, &nouns.Queue{
-		Text: name,
-	})
+	d.QueueWithAttributes(nouns.QueueAttributes{}, name)
 }
 
 func (d *Dial) QueueWithAttributes(attributes nouns.QueueAttributes, name string) {
 	d.Children = append(d.Children, &nouns.Queue{
-		QueueAttributes: &attributes,
+		QueueAttributes: attributes,
 		Text:            name,
 	})
 }
@@ -100,9 +89,7 @@ func (d *Dial) Sim(simSid string) {
 }
 
 func (d *Dial) Sip(sipURL string) {
-	d.Children = append(d.Children, &nouns.Sip{
-		Text: sipURL,
-	})
+	d.SipWithAttributes(nouns.SipAttributes{}, sipURL)
 }
 
 func (d *Dial) SipWithAttributes(attributes nouns.SipAttributes, sipURL string) {

--- a/twiml/voice/verbs/enqueue.go
+++ b/twiml/voice/verbs/enqueue.go
@@ -19,18 +19,15 @@ type Enqueue struct {
 	Text    *string  `xml:",chardata"`
 
 	EnqueueAttributes
-
 	Children []interface{}
 }
 
-func (c *Enqueue) Task(body string) {
-	c.Children = append(c.Children, nouns.Task{
-		Text: body,
-	})
+func (e *Enqueue) Task(body string) {
+	e.TaskWithAttributes(nouns.TaskAttributes{}, body)
 }
 
-func (c *Enqueue) TaskWithAttributes(attributes nouns.TaskAttributes, body string) {
-	c.Children = append(c.Children, nouns.Task{
+func (e *Enqueue) TaskWithAttributes(attributes nouns.TaskAttributes, body string) {
+	e.Children = append(e.Children, nouns.Task{
 		Text:           body,
 		TaskAttributes: attributes,
 	})

--- a/twiml/voice/verbs/gather.go
+++ b/twiml/voice/verbs/gather.go
@@ -28,43 +28,38 @@ type GatherAttributes struct {
 type Gather struct {
 	XMLName xml.Name `xml:"Gather"`
 
-	*GatherAttributes
-
+	GatherAttributes
 	Children []interface{}
 }
 
 func (g *Gather) Pause() {
-	g.Children = append(g.Children, &Pause{})
+	g.PauseWithAttributes(PauseAttributes{})
 }
 
 func (g *Gather) PauseWithAttributes(attributes PauseAttributes) {
 	g.Children = append(g.Children, &Pause{
-		PauseAttributes: &attributes,
+		PauseAttributes: attributes,
 	})
 }
 
 func (g *Gather) Play(url *string) {
-	g.Children = append(g.Children, &Play{
-		Text: url,
-	})
+	g.PlayWithAttributes(PlayAttributes{}, url)
 }
 
 func (g *Gather) PlayWithAttributes(attributes PlayAttributes, url *string) {
 	g.Children = append(g.Children, &Play{
 		Text:           url,
-		PlayAttributes: &attributes,
+		PlayAttributes: attributes,
 	})
 }
 
 func (g *Gather) Say(message string) {
-	g.Children = append(g.Children, &Say{
-		Text: message,
-	})
+	g.SayWithAttributes(SayAttributes{}, message)
 }
 
 func (g *Gather) SayWithAttributes(attributes SayAttributes, message string) {
 	g.Children = append(g.Children, &Say{
 		Text:          message,
-		SayAttributes: &attributes,
+		SayAttributes: attributes,
 	})
 }

--- a/twiml/voice/verbs/hangup.go
+++ b/twiml/voice/verbs/hangup.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Hangup struct {
 	XMLName xml.Name `xml:"Hangup"`

--- a/twiml/voice/verbs/leave.go
+++ b/twiml/voice/verbs/leave.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Leave struct {
 	XMLName xml.Name `xml:"Leave"`

--- a/twiml/voice/verbs/nouns/autopilot.go
+++ b/twiml/voice/verbs/nouns/autopilot.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Autopilot struct {
 	XMLName xml.Name `xml:"Autopilot"`

--- a/twiml/voice/verbs/nouns/client.go
+++ b/twiml/voice/verbs/nouns/client.go
@@ -17,7 +17,6 @@ type Client struct {
 	Text    *string  `xml:",chardata"`
 
 	ClientAttributes
-
 	Children []interface{}
 }
 
@@ -28,11 +27,11 @@ func (c *Client) Identity(clientIdentity string) {
 }
 
 func (c *Client) Parameter() {
-	c.Children = append(c.Children, &Parameter{})
+	c.ParameterWithAttributes(ParameterAttributes{})
 }
 
 func (c *Client) ParameterWithAttributes(attributes ParameterAttributes) {
 	c.Children = append(c.Children, &Parameter{
-		ParameterAttributes: &attributes,
+		ParameterAttributes: attributes,
 	})
 }

--- a/twiml/voice/verbs/nouns/conference.go
+++ b/twiml/voice/verbs/nouns/conference.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type ConferenceAttributes struct {
 	Beep                          *string `xml:"beep,attr,omitempty"`

--- a/twiml/voice/verbs/nouns/identity.go
+++ b/twiml/voice/verbs/nouns/identity.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Identity struct {
 	XMLName xml.Name `xml:"Identity"`

--- a/twiml/voice/verbs/nouns/number.go
+++ b/twiml/voice/verbs/nouns/number.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type NumberAttributes struct {
 	BYOC                 *string `xml:"byoc,attr,omitempty"`

--- a/twiml/voice/verbs/nouns/parameter.go
+++ b/twiml/voice/verbs/nouns/parameter.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type ParameterAttributes struct {
 	Name  *string `xml:"name,attr,omitempty"`
@@ -10,5 +12,5 @@ type ParameterAttributes struct {
 type Parameter struct {
 	XMLName xml.Name `xml:"Parameter"`
 
-	*ParameterAttributes
+	ParameterAttributes
 }

--- a/twiml/voice/verbs/nouns/queue.go
+++ b/twiml/voice/verbs/nouns/queue.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type QueueAttributes struct {
 	Method              *string `xml:"method,attr,omitempty"`
@@ -13,5 +15,5 @@ type Queue struct {
 	XMLName xml.Name `xml:"Queue"`
 	Text    string   `xml:",chardata"`
 
-	*QueueAttributes
+	QueueAttributes
 }

--- a/twiml/voice/verbs/nouns/refer_sip.go
+++ b/twiml/voice/verbs/nouns/refer_sip.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type ReferSipAttributes struct {
 	Method               *string `xml:"method,attr,omitempty"`

--- a/twiml/voice/verbs/nouns/room.go
+++ b/twiml/voice/verbs/nouns/room.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type RoomAttributes struct {
 	ParticipantIdentity *string `xml:"participantIdentity,attr,omitempty"`

--- a/twiml/voice/verbs/nouns/sim.go
+++ b/twiml/voice/verbs/nouns/sim.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type Sim struct {
 	XMLName xml.Name `xml:"Sim"`

--- a/twiml/voice/verbs/nouns/sip.go
+++ b/twiml/voice/verbs/nouns/sip.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type SipAttributes struct {
 	Method               *string `xml:"method,attr,omitempty"`

--- a/twiml/voice/verbs/nouns/siprec.go
+++ b/twiml/voice/verbs/nouns/siprec.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type SiprecAttributes struct {
 	ConnectorName *string `xml:"connectorName,attr,omitempty"`
@@ -11,17 +13,16 @@ type SiprecAttributes struct {
 type Siprec struct {
 	XMLName xml.Name `xml:"Siprec"`
 
-	*SiprecAttributes
-
+	SiprecAttributes
 	Children []interface{}
 }
 
 func (s *Siprec) Parameter() {
-	s.Children = append(s.Children, &Parameter{})
+	s.ParameterWithAttributes(ParameterAttributes{})
 }
 
 func (s *Siprec) ParameterWithAttributes(attributes ParameterAttributes) {
 	s.Children = append(s.Children, &Parameter{
-		ParameterAttributes: &attributes,
+		ParameterAttributes: attributes,
 	})
 }

--- a/twiml/voice/verbs/nouns/stream.go
+++ b/twiml/voice/verbs/nouns/stream.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type StreamAttributes struct {
 	ConnectorName        *string `xml:"connectorName,attr,omitempty"`
@@ -14,16 +16,16 @@ type StreamAttributes struct {
 type Stream struct {
 	XMLName xml.Name `xml:"Stream"`
 
-	*StreamAttributes
+	StreamAttributes
 	Children []interface{}
 }
 
 func (s *Stream) Parameter() {
-	s.Children = append(s.Children, &Parameter{})
+	s.ParameterWithAttributes(ParameterAttributes{})
 }
 
 func (s *Stream) ParameterWithAttributes(attributes ParameterAttributes) {
 	s.Children = append(s.Children, &Parameter{
-		ParameterAttributes: &attributes,
+		ParameterAttributes: attributes,
 	})
 }

--- a/twiml/voice/verbs/nouns/task.go
+++ b/twiml/voice/verbs/nouns/task.go
@@ -1,6 +1,8 @@
 package nouns
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type TaskAttributes struct {
 	Priority *int `xml:"priority,attr,omitempty"`

--- a/twiml/voice/verbs/pause.go
+++ b/twiml/voice/verbs/pause.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type PauseAttributes struct {
 	Length *int `xml:"length,attr,omitempty"`
@@ -9,5 +11,5 @@ type PauseAttributes struct {
 type Pause struct {
 	XMLName xml.Name `xml:"Pause"`
 
-	*PauseAttributes
+	PauseAttributes
 }

--- a/twiml/voice/verbs/pay.go
+++ b/twiml/voice/verbs/pay.go
@@ -30,30 +30,27 @@ type PayAttributes struct {
 type Pay struct {
 	XMLName xml.Name `xml:"Pay"`
 
-	*PayAttributes
-
+	PayAttributes
 	Children []interface{}
 }
 
 func (p *Pay) Parameter() {
-	p.Children = append(p.Children, &nouns.Parameter{})
+	p.ParameterWithAttributes(nouns.ParameterAttributes{})
 }
 
 func (p *Pay) ParameterWithAttributes(attributes nouns.ParameterAttributes) {
 	p.Children = append(p.Children, &nouns.Parameter{
-		ParameterAttributes: &attributes,
+		ParameterAttributes: attributes,
 	})
 }
 
 func (p *Pay) Prompt() *Prompt {
-	prompt := &Prompt{}
-	p.Children = append(p.Children, prompt)
-	return prompt
+	return p.PromptWithAttributes(PromptAttributes{})
 }
 
 func (p *Pay) PromptWithAttributes(attributes PromptAttributes) *Prompt {
 	prompt := &Prompt{
-		PromptAttributes: &attributes,
+		PromptAttributes: attributes,
 	}
 	p.Children = append(p.Children, prompt)
 	return prompt

--- a/twiml/voice/verbs/play.go
+++ b/twiml/voice/verbs/play.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type PlayAttributes struct {
 	Digits *string `xml:"digits,attr,omitempty"`
@@ -11,5 +13,5 @@ type Play struct {
 	XMLName xml.Name `xml:"Play"`
 	Text    *string  `xml:",chardata"`
 
-	*PlayAttributes
+	PlayAttributes
 }

--- a/twiml/voice/verbs/prompt.go
+++ b/twiml/voice/verbs/prompt.go
@@ -14,18 +14,17 @@ type PromptAttributes struct {
 type Prompt struct {
 	XMLName xml.Name `xml:"Prompt"`
 
-	*PromptAttributes
-
+	PromptAttributes
 	Children []interface{}
 }
 
 func (p *Prompt) Pause() {
-	p.Children = append(p.Children, &Pause{})
+	p.PauseWithAttributes(PauseAttributes{})
 }
 
 func (p *Prompt) PauseWithAttributes(attributes PauseAttributes) {
 	p.Children = append(p.Children, &Pause{
-		PauseAttributes: &attributes,
+		PauseAttributes: attributes,
 	})
 }
 
@@ -36,14 +35,12 @@ func (p *Prompt) Play(url *string) {
 }
 
 func (p *Prompt) Say(message string) {
-	p.Children = append(p.Children, &Say{
-		Text: message,
-	})
+	p.SayWithAttributes(SayAttributes{}, message)
 }
 
 func (p *Prompt) SayWithAttributes(attributes SayAttributes, message string) {
 	p.Children = append(p.Children, &Say{
 		Text:          message,
-		SayAttributes: &attributes,
+		SayAttributes: attributes,
 	})
 }

--- a/twiml/voice/verbs/record.go
+++ b/twiml/voice/verbs/record.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type RecordAttributes struct {
 	Action                        *string `xml:"action,attr,omitempty"`
@@ -20,5 +22,5 @@ type RecordAttributes struct {
 type Record struct {
 	XMLName xml.Name `xml:"Record"`
 
-	*RecordAttributes
+	RecordAttributes
 }

--- a/twiml/voice/verbs/redirect.go
+++ b/twiml/voice/verbs/redirect.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type RedirectAttributes struct {
 	Method *string `xml:"method,attr,omitempty"`
@@ -10,5 +12,5 @@ type Redirect struct {
 	XMLName xml.Name `xml:"Redirect"`
 	Text    string   `xml:",chardata"`
 
-	*RedirectAttributes
+	RedirectAttributes
 }

--- a/twiml/voice/verbs/refer.go
+++ b/twiml/voice/verbs/refer.go
@@ -14,14 +14,12 @@ type ReferAttributes struct {
 type Refer struct {
 	XMLName xml.Name `xml:"Refer"`
 
-	*ReferAttributes
+	ReferAttributes
 	Children []interface{}
 }
 
 func (r *Refer) ReferSip(sipURL string) {
-	r.Children = append(r.Children, &nouns.ReferSip{
-		Text: sipURL,
-	})
+	r.ReferSipWithAttributes(nouns.ReferSipAttributes{}, sipURL)
 }
 
 func (r *Refer) ReferSipWithAttributes(attributes nouns.ReferSipAttributes, sipURL string) {
@@ -32,9 +30,7 @@ func (r *Refer) ReferSipWithAttributes(attributes nouns.ReferSipAttributes, sipU
 }
 
 func (r *Refer) Sip(sipURL string) {
-	r.Children = append(r.Children, &nouns.Sip{
-		Text: sipURL,
-	})
+	r.SipWithAttributes(nouns.SipAttributes{}, sipURL)
 }
 
 func (r *Refer) SipWithAttributes(attributes nouns.SipAttributes, sipURL string) {

--- a/twiml/voice/verbs/reject.go
+++ b/twiml/voice/verbs/reject.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type RejectAttributes struct {
 	Reason *string `xml:"reason,attr,omitempty"`
@@ -9,5 +11,5 @@ type RejectAttributes struct {
 type Reject struct {
 	XMLName xml.Name `xml:"Reject"`
 
-	*RejectAttributes
+	RejectAttributes
 }

--- a/twiml/voice/verbs/say.go
+++ b/twiml/voice/verbs/say.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type SayAttributes struct {
 	Language *string `xml:"language,attr,omitempty"`
@@ -12,5 +14,5 @@ type Say struct {
 	XMLName xml.Name `xml:"Say"`
 	Text    string   `xml:",chardata"`
 
-	*SayAttributes
+	SayAttributes
 }

--- a/twiml/voice/verbs/sms.go
+++ b/twiml/voice/verbs/sms.go
@@ -1,6 +1,8 @@
 package verbs
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+)
 
 type SmsAttributes struct {
 	Action         *string `xml:"action,attr,omitempty"`
@@ -14,5 +16,5 @@ type Sms struct {
 	XMLName xml.Name `xml:"Sms"`
 	Text    string   `xml:",chardata"`
 
-	*SmsAttributes
+	SmsAttributes
 }

--- a/twiml/voice/verbs/start.go
+++ b/twiml/voice/verbs/start.go
@@ -14,22 +14,17 @@ type StartAttributes struct {
 type Start struct {
 	XMLName xml.Name `xml:"Start"`
 
-	*StartAttributes
-
+	StartAttributes
 	Children []interface{}
 }
 
 func (s *Start) Siprec() *nouns.Siprec {
-	siprec := &nouns.Siprec{
-		Children: make([]interface{}, 0),
-	}
-	s.Children = append(s.Children, siprec)
-	return siprec
+	return s.SiprecWithAttributes(nouns.SiprecAttributes{})
 }
 
 func (s *Start) SiprecWithAttributes(attributes nouns.SiprecAttributes) *nouns.Siprec {
 	siprec := &nouns.Siprec{
-		SiprecAttributes: &attributes,
+		SiprecAttributes: attributes,
 		Children:         make([]interface{}, 0),
 	}
 	s.Children = append(s.Children, siprec)
@@ -37,16 +32,12 @@ func (s *Start) SiprecWithAttributes(attributes nouns.SiprecAttributes) *nouns.S
 }
 
 func (s *Start) Stream() *nouns.Stream {
-	stream := &nouns.Stream{
-		Children: make([]interface{}, 0),
-	}
-	s.Children = append(s.Children, stream)
-	return stream
+	return s.StreamWithAttributes(nouns.StreamAttributes{})
 }
 
 func (s *Start) StreamWithAttributes(attributes nouns.StreamAttributes) *nouns.Stream {
 	stream := &nouns.Stream{
-		StreamAttributes: &attributes,
+		StreamAttributes: attributes,
 		Children:         make([]interface{}, 0),
 	}
 	s.Children = append(s.Children, stream)

--- a/twiml/voice/verbs/stop.go
+++ b/twiml/voice/verbs/stop.go
@@ -14,22 +14,17 @@ type StopAttributes struct {
 type Stop struct {
 	XMLName xml.Name `xml:"Stop"`
 
-	*StopAttributes
-
+	StopAttributes
 	Children []interface{}
 }
 
 func (s *Stop) Siprec() *nouns.Siprec {
-	siprec := &nouns.Siprec{
-		Children: make([]interface{}, 0),
-	}
-	s.Children = append(s.Children, siprec)
-	return siprec
+	return s.SiprecWithAttributes(nouns.SiprecAttributes{})
 }
 
 func (s *Stop) SiprecWithAttributes(attributes nouns.SiprecAttributes) *nouns.Siprec {
 	siprec := &nouns.Siprec{
-		SiprecAttributes: &attributes,
+		SiprecAttributes: attributes,
 		Children:         make([]interface{}, 0),
 	}
 	s.Children = append(s.Children, siprec)
@@ -37,16 +32,12 @@ func (s *Stop) SiprecWithAttributes(attributes nouns.SiprecAttributes) *nouns.Si
 }
 
 func (s *Stop) Stream() *nouns.Stream {
-	stream := &nouns.Stream{
-		Children: make([]interface{}, 0),
-	}
-	s.Children = append(s.Children, stream)
-	return stream
+	return s.StreamWithAttributes(nouns.StreamAttributes{})
 }
 
 func (s *Stop) StreamWithAttributes(attributes nouns.StreamAttributes) *nouns.Stream {
 	stream := &nouns.Stream{
-		StreamAttributes: &attributes,
+		StreamAttributes: attributes,
 		Children:         make([]interface{}, 0),
 	}
 	s.Children = append(s.Children, stream)

--- a/twiml/voice/voice_response.go
+++ b/twiml/voice/voice_response.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/RJPearson94/twilio-sdk-go/twiml/voice/verbs"
 	"github.com/RJPearson94/twilio-sdk-go/twiml/voice/verbs/nouns"
+	"github.com/RJPearson94/twilio-sdk-go/utils"
 )
 
 // VoiceResponse provides the structure and functions for generation TwiML that can be used
 // on Programmable Voice. See https://www.twilio.com/docs/voice/twiml for more details
 type VoiceResponse struct {
-	XMLName  xml.Name `xml:"Response"`
+	XMLName xml.Name `xml:"Response"`
+
 	Children []interface{}
 }
 
@@ -21,279 +23,230 @@ func New() *VoiceResponse {
 	}
 }
 
-func (m *VoiceResponse) Connect() *verbs.Connect {
-	connect := &verbs.Connect{
-		Children: make([]interface{}, 0),
-	}
-
-	m.Children = append(m.Children, connect)
-	return connect
+func (v *VoiceResponse) Connect() *verbs.Connect {
+	return v.ConnectWithAttributes(verbs.ConnectAttributes{})
 }
 
-func (m *VoiceResponse) ConnectWithAttributes(attributes verbs.ConnectAttributes) *verbs.Connect {
+func (v *VoiceResponse) ConnectWithAttributes(attributes verbs.ConnectAttributes) *verbs.Connect {
 	connect := &verbs.Connect{
-		ConnectAttributes: &attributes,
+		ConnectAttributes: attributes,
 		Children:          make([]interface{}, 0),
 	}
 
-	m.Children = append(m.Children, connect)
+	v.Children = append(v.Children, connect)
 	return connect
 }
 
-func (m *VoiceResponse) Dial(phoneNumber *string) *verbs.Dial {
-	dial := &verbs.Dial{
-		Text:     phoneNumber,
-		Children: make([]interface{}, 0),
-	}
-
-	m.Children = append(m.Children, dial)
-	return dial
+func (v *VoiceResponse) Dial(phoneNumber *string) *verbs.Dial {
+	return v.DialWithAttributes(verbs.DialAttributes{}, phoneNumber)
 }
 
-func (m *VoiceResponse) DialWithAttributes(attributes verbs.DialAttributes, phoneNumber *string) *verbs.Dial {
+func (v *VoiceResponse) DialWithAttributes(attributes verbs.DialAttributes, phoneNumber *string) *verbs.Dial {
 	dial := &verbs.Dial{
 		DialAttributes: attributes,
 		Text:           phoneNumber,
 		Children:       make([]interface{}, 0),
 	}
 
-	m.Children = append(m.Children, dial)
+	v.Children = append(v.Children, dial)
 	return dial
 }
 
-func (m *VoiceResponse) Enqueue(name *string) *verbs.Enqueue {
-	enqueue := &verbs.Enqueue{
-		Text:     name,
-		Children: make([]interface{}, 0),
-	}
-
-	m.Children = append(m.Children, enqueue)
-	return enqueue
+func (v *VoiceResponse) Enqueue(name *string) *verbs.Enqueue {
+	return v.EnqueueWithAttributes(verbs.EnqueueAttributes{}, name)
 }
 
-func (m *VoiceResponse) EnqueueWithAttributes(attributes verbs.EnqueueAttributes, name *string) *verbs.Enqueue {
+func (v *VoiceResponse) EnqueueWithAttributes(attributes verbs.EnqueueAttributes, name *string) *verbs.Enqueue {
 	enqueue := &verbs.Enqueue{
 		EnqueueAttributes: attributes,
 		Text:              name,
 		Children:          make([]interface{}, 0),
 	}
 
-	m.Children = append(m.Children, enqueue)
+	v.Children = append(v.Children, enqueue)
 	return enqueue
 }
 
-func (m *VoiceResponse) Gather() *verbs.Gather {
-	gather := &verbs.Gather{
-		Children: make([]interface{}, 0),
-	}
-
-	m.Children = append(m.Children, gather)
-	return gather
+func (v *VoiceResponse) Gather() *verbs.Gather {
+	return v.GatherWithAttributes(verbs.GatherAttributes{})
 }
 
-func (m *VoiceResponse) GatherWithAttributes(attributes verbs.GatherAttributes) *verbs.Gather {
+func (v *VoiceResponse) GatherWithAttributes(attributes verbs.GatherAttributes) *verbs.Gather {
 	gather := &verbs.Gather{
-		GatherAttributes: &attributes,
+		GatherAttributes: attributes,
 		Children:         make([]interface{}, 0),
 	}
 
-	m.Children = append(m.Children, gather)
+	v.Children = append(v.Children, gather)
 	return gather
 }
 
-func (m *VoiceResponse) Hangup() {
-	m.Children = append(m.Children, &verbs.Hangup{})
+func (v *VoiceResponse) Hangup() {
+	v.Children = append(v.Children, &verbs.Hangup{})
 }
 
-func (m *VoiceResponse) Leave() {
-	m.Children = append(m.Children, &verbs.Leave{})
+func (v *VoiceResponse) Leave() {
+	v.Children = append(v.Children, &verbs.Leave{})
 }
 
-func (m *VoiceResponse) Pause() {
-	m.Children = append(m.Children, &verbs.Pause{})
+func (v *VoiceResponse) Pause() {
+	v.PauseWithAttributes(verbs.PauseAttributes{})
 }
 
-func (m *VoiceResponse) PauseWithAttributes(attributes verbs.PauseAttributes) {
-	m.Children = append(m.Children, &verbs.Pause{
-		PauseAttributes: &attributes,
+func (v *VoiceResponse) PauseWithAttributes(attributes verbs.PauseAttributes) {
+	v.Children = append(v.Children, &verbs.Pause{
+		PauseAttributes: attributes,
 	})
 }
 
-func (m *VoiceResponse) Pay() *verbs.Pay {
-	pay := &verbs.Pay{
-		Children: make([]interface{}, 0),
-	}
-	m.Children = append(m.Children, pay)
-	return pay
+func (v *VoiceResponse) Pay() *verbs.Pay {
+	return v.PayWithAttributes(verbs.PayAttributes{})
 }
 
-func (m *VoiceResponse) PayWithAttributes(attributes verbs.PayAttributes) *verbs.Pay {
+func (v *VoiceResponse) PayWithAttributes(attributes verbs.PayAttributes) *verbs.Pay {
 	pay := &verbs.Pay{
-		PayAttributes: &attributes,
+		PayAttributes: attributes,
 		Children:      make([]interface{}, 0),
 	}
-	m.Children = append(m.Children, pay)
+	v.Children = append(v.Children, pay)
 	return pay
 }
 
-func (m *VoiceResponse) Play(url *string) {
-	m.Children = append(m.Children, &verbs.Play{
-		Text: url,
-	})
+func (v *VoiceResponse) Play(url *string) {
+	v.PlayWithAttributes(verbs.PlayAttributes{}, url)
 }
 
-func (m *VoiceResponse) PlayWithAttributes(attributes verbs.PlayAttributes, url *string) {
-	m.Children = append(m.Children, &verbs.Play{
+func (v *VoiceResponse) PlayWithAttributes(attributes verbs.PlayAttributes, url *string) {
+	v.Children = append(v.Children, &verbs.Play{
 		Text:           url,
-		PlayAttributes: &attributes,
+		PlayAttributes: attributes,
 	})
 }
 
-func (m *VoiceResponse) Prompt() *verbs.Prompt {
-	prompt := &verbs.Prompt{}
-	m.Children = append(m.Children, prompt)
-	return prompt
+func (v *VoiceResponse) Prompt() *verbs.Prompt {
+	return v.PromptWithAttributes(verbs.PromptAttributes{})
 }
 
-func (m *VoiceResponse) PromptWithAttributes(attributes verbs.PromptAttributes) *verbs.Prompt {
+func (v *VoiceResponse) PromptWithAttributes(attributes verbs.PromptAttributes) *verbs.Prompt {
 	prompt := &verbs.Prompt{
-		PromptAttributes: &attributes,
+		PromptAttributes: attributes,
 	}
-	m.Children = append(m.Children, prompt)
+	v.Children = append(v.Children, prompt)
 	return prompt
 }
 
-func (m *VoiceResponse) Queue(name string) {
-	m.Children = append(m.Children, &nouns.Queue{
-		Text: name,
-	})
+func (v *VoiceResponse) Queue(name string) {
+	v.QueueWithAttributes(nouns.QueueAttributes{}, name)
 }
 
-func (m *VoiceResponse) QueueWithAttributes(attributes nouns.QueueAttributes, name string) {
-	m.Children = append(m.Children, &nouns.Queue{
-		QueueAttributes: &attributes,
+func (v *VoiceResponse) QueueWithAttributes(attributes nouns.QueueAttributes, name string) {
+	v.Children = append(v.Children, &nouns.Queue{
+		QueueAttributes: attributes,
 		Text:            name,
 	})
 }
 
-func (m *VoiceResponse) Record() {
-	m.Children = append(m.Children, &verbs.Record{})
+func (v *VoiceResponse) Record() {
+	v.RecordWithAttributes(verbs.RecordAttributes{})
 }
 
-func (m *VoiceResponse) RecordWithAttributes(attributes verbs.RecordAttributes) {
-	m.Children = append(m.Children, &verbs.Record{
-		RecordAttributes: &attributes,
+func (v *VoiceResponse) RecordWithAttributes(attributes verbs.RecordAttributes) {
+	v.Children = append(v.Children, &verbs.Record{
+		RecordAttributes: attributes,
 	})
 }
 
-func (m *VoiceResponse) Redirect(url string) {
-	m.Children = append(m.Children, &verbs.Redirect{
-		Text: url,
-	})
+func (v *VoiceResponse) Redirect(url string) {
+	v.RedirectWithAttributes(verbs.RedirectAttributes{}, url)
 }
 
-func (m *VoiceResponse) RedirectWithAttributes(attributes verbs.RedirectAttributes, url string) {
-	m.Children = append(m.Children, &verbs.Redirect{
+func (v *VoiceResponse) RedirectWithAttributes(attributes verbs.RedirectAttributes, url string) {
+	v.Children = append(v.Children, &verbs.Redirect{
 		Text:               url,
-		RedirectAttributes: &attributes,
+		RedirectAttributes: attributes,
 	})
 }
 
-func (m *VoiceResponse) Refer() *verbs.Refer {
-	refer := &verbs.Refer{}
-	m.Children = append(m.Children, refer)
-	return refer
+func (v *VoiceResponse) Refer() *verbs.Refer {
+	return v.ReferWithAttributes(verbs.ReferAttributes{})
 }
 
-func (m *VoiceResponse) ReferWithAttributes(attributes verbs.ReferAttributes) *verbs.Refer {
+func (v *VoiceResponse) ReferWithAttributes(attributes verbs.ReferAttributes) *verbs.Refer {
 	refer := &verbs.Refer{
-		ReferAttributes: &attributes,
+		ReferAttributes: attributes,
 	}
-	m.Children = append(m.Children, refer)
+	v.Children = append(v.Children, refer)
 	return refer
 }
 
-func (m *VoiceResponse) Reject() {
-	m.Children = append(m.Children, &verbs.Reject{})
+func (v *VoiceResponse) Reject() {
+	v.RejectWithAttributes(verbs.RejectAttributes{})
 }
 
-func (m *VoiceResponse) RejectWithAttributes(attributes verbs.RejectAttributes) {
-	m.Children = append(m.Children, &verbs.Reject{
-		RejectAttributes: &attributes,
+func (v *VoiceResponse) RejectWithAttributes(attributes verbs.RejectAttributes) {
+	v.Children = append(v.Children, &verbs.Reject{
+		RejectAttributes: attributes,
 	})
 }
 
-func (m *VoiceResponse) Say(message string) {
-	m.Children = append(m.Children, &verbs.Say{
-		Text: message,
-	})
+func (v *VoiceResponse) Say(message string) {
+	v.SayWithAttributes(verbs.SayAttributes{}, message)
 }
 
-func (m *VoiceResponse) SayWithAttributes(attributes verbs.SayAttributes, message string) {
-	m.Children = append(m.Children, &verbs.Say{
+func (v *VoiceResponse) SayWithAttributes(attributes verbs.SayAttributes, message string) {
+	v.Children = append(v.Children, &verbs.Say{
 		Text:          message,
-		SayAttributes: &attributes,
+		SayAttributes: attributes,
 	})
 }
 
-func (m *VoiceResponse) Sms(message string) {
-	m.Children = append(m.Children, &verbs.Sms{
-		Text: message,
-	})
+func (v *VoiceResponse) Sms(message string) {
+	v.SmsWithAttributes(verbs.SmsAttributes{}, message)
 }
 
-func (m *VoiceResponse) SmsWithAttributes(attributes verbs.SmsAttributes, message string) {
-	m.Children = append(m.Children, &verbs.Sms{
+func (v *VoiceResponse) SmsWithAttributes(attributes verbs.SmsAttributes, message string) {
+	v.Children = append(v.Children, &verbs.Sms{
 		Text:          message,
-		SmsAttributes: &attributes,
+		SmsAttributes: attributes,
 	})
 }
 
-func (m *VoiceResponse) Start() *verbs.Start {
-	start := &verbs.Start{
-		Children: make([]interface{}, 0),
-	}
-	m.Children = append(m.Children, start)
-	return start
+func (v *VoiceResponse) Start() *verbs.Start {
+	return v.StartWithAttributes(verbs.StartAttributes{})
 }
 
-func (m *VoiceResponse) StartWithAttributes(attributes verbs.StartAttributes) *verbs.Start {
+func (v *VoiceResponse) StartWithAttributes(attributes verbs.StartAttributes) *verbs.Start {
 	start := &verbs.Start{
-		StartAttributes: &attributes,
+		StartAttributes: attributes,
 		Children:        make([]interface{}, 0),
 	}
-	m.Children = append(m.Children, start)
+	v.Children = append(v.Children, start)
 	return start
 }
 
-func (m *VoiceResponse) Stop() *verbs.Stop {
-	stop := &verbs.Stop{
-		Children: make([]interface{}, 0),
-	}
-	m.Children = append(m.Children, stop)
-	return stop
+func (v *VoiceResponse) Stop() *verbs.Stop {
+	return v.StopWithAttributes(verbs.StopAttributes{})
 }
 
-func (m *VoiceResponse) StopWithAttributes(attributes verbs.StopAttributes) *verbs.Stop {
+func (v *VoiceResponse) StopWithAttributes(attributes verbs.StopAttributes) *verbs.Stop {
 	stop := &verbs.Stop{
-		StopAttributes: &attributes,
+		StopAttributes: attributes,
 		Children:       make([]interface{}, 0),
 	}
-	m.Children = append(m.Children, stop)
+	v.Children = append(v.Children, stop)
 	return stop
 }
 
 // ToTwiML generates the TwiML string or returns an error if the response cannot be marshalled
-func (m *VoiceResponse) ToTwiML() (*string, error) {
-	return m.ToString()
+func (v *VoiceResponse) ToTwiML() (*string, error) {
+	return v.ToString()
 }
 
 // ToString generates the TwiML string or returns an error if the response cannot be marshalled
-func (m *VoiceResponse) ToString() (*string, error) {
-	output, err := xml.Marshal(m)
+func (v *VoiceResponse) ToString() (*string, error) {
+	output, err := xml.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
-	twiML := xml.Header + string(output)
-	return &twiML, nil
+	return utils.String(xml.Header + string(output)), nil
 }


### PR DESCRIPTION
With the pointers on noun and verb attributes, golang panics with the following error `panic: reflect: call of reflect.Value.CanInterface on zero Value` on golang 1.15.x and above. This introduces consistency in the twiml implementation
Tidy up unnecessary code and improve consistency in twiml code